### PR TITLE
Handle ServiceUnavailableError and APIConnectionError properly

### DIFF
--- a/conv_rec_system.py
+++ b/conv_rec_system.py
@@ -204,8 +204,8 @@ class ConvRecSystem(WarningObserver):
         :param retry_info: dictionary that contains information about retry
         """
         if not self.is_gpt_retry_notified:
-            if isinstance(retry_info.get('output'), openai.error.ServiceUnavailableError) or \
-                    isinstance(retry_info.get('output'), openai.error.APIConnectionError):
+            if isinstance(retry_info.get('outcome').exception(), openai.error.ServiceUnavailableError) or \
+                    isinstance(retry_info.get('outcome').exception(), openai.error.APIConnectionError):
                 self.user_interface.display_warning(
                     "There were some issues with the OpenAI server. It might take longer than usual.")
             else:


### PR DESCRIPTION
Handle ServiceUnavailableError and APIConnectionError properly so that it prints appropriate message.